### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 crytic_compile==0.2.3
 slither-analyzer==0.8.3
-eth_abi==2.1.1
+eth_abi==1.3.0
 py_solc_x==1.1.1
 pycryptodome==3.14.1
 pysha3==1.0.2


### PR DESCRIPTION
collapse_type is removed from eth_abi 2.0, so need to use eth_abi 1.3.0 

Below is the error running python -m peth
 >
File "C:\ProgramData\Miniconda3\lib\site-packages\web3\utils\abi.py", line 10, in <module>
    from eth_abi.abi import (
ImportError: cannot import name 'collapse_type' from 'eth_abi.abi' (C:\ProgramData\Miniconda3\lib\site-packages\eth_abi\abi.py)