### PR TITLE
Fix CREATE/CREATE2 handling in internal transactions

### DIFF
--- a/peth/eth/evm/transaction.py
+++ b/peth/eth/evm/transaction.py
@@ -124,7 +124,7 @@ class Transaction(object):
         if op in [OpCode.CALLCODE, OpCode.DELEGATECALL]:
             tx.to = self.to  # Keep the storage address unchanged.
             tx.code_address = to  # And use the `to` code.
-        elif op is [OpCode.CREATE, OpCode.CREATE2]:
+        elif op in [OpCode.CREATE, OpCode.CREATE2]:
             tx.to = None
         else:
             tx.to = to


### PR DESCRIPTION
## Summary
- fix wrong `is` comparison that prevented proper contract creation logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hexbytes')*

------
https://chatgpt.com/codex/tasks/task_b_683fbffbb2848327b9deb275cab3a9b9