### PR TITLE
Fix CALL/ CALLCODE pop in VM

### DIFF
--- a/peth/eth/evm/vm.py
+++ b/peth/eth/evm/vm.py
@@ -647,7 +647,7 @@ class VM(object):
     def _do_call(self):
         gas, to = self._stack_pop_values(2)
         to = uint_to_address(to)
-        if self._current_ins.op in [OpCode.CALL or OpCode.CALLCODE]:
+        if self._current_ins.op in [OpCode.CALL, OpCode.CALLCODE]:
             value = self._stack_pop()
         else:
             value = 0


### PR DESCRIPTION
## Summary
- fix a bug where CALLCODE would not pop value off the stack

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hexbytes')*

------
https://chatgpt.com/codex/tasks/task_b_683fbfe541ec8327ab75c468fffb5bf9