### PR TITLE
Fix typo in console docstring

### DIFF
--- a/peth/console.py
+++ b/peth/console.py
@@ -141,7 +141,7 @@ class PethConsole(cmd.Cmd):
         """
         Simple command line arguments parser.
 
-        auto: Split to arguments and covert numbers and addresses.
+        auto: Split to arguments and convert numbers and addresses.
 
         address: if not address raise an error.
         number: if not number raise an error.


### PR DESCRIPTION
## Summary
- fix docstring comment typo in `_parse_args`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hexbytes')*

------
https://chatgpt.com/codex/tasks/task_b_683fc4961578832794a86c02feda5dc7