### PR TITLE
Fix 'Retrieve' typo

### DIFF
--- a/peth/core/peth.py
+++ b/peth/core/peth.py
@@ -35,7 +35,7 @@ class Peth(Web3Ex):
 
     def get_view_value(self, contract, name, typ=None):
         """
-        Retrive contract view values. such as `name()->(string)`.
+        Retrieve contract view values, such as ``name()->(string)``.
         """
         if typ:
             sig = f"{name}()->({typ})"


### PR DESCRIPTION
## Summary
- fix docstring typo in `get_view_value`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_683fc46fd0708327be689f429c44460c