### PR TITLE
Fix tuple arg parsing and add test

### DIFF
--- a/peth/console.py
+++ b/peth/console.py
@@ -179,7 +179,7 @@ class PethConsole(cmd.Cmd):
             ), f"Invalid args count: {len(typ)} need. {len(args)} found."
             r = []
             for a, t in zip(args, typ):
-                return self._parse_args(a, t)
+                r.append(self._parse_args(a, t))
             return r
         else:
             raise Exception("_parse_args: invalid type")

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,7 @@
+from peth.console import PethConsole
+
+
+def test_parse_args_tuple():
+    console = PethConsole(None)
+    result = console._parse_args("1 foo", ("number", "string"))
+    assert result == [1, "foo"]


### PR DESCRIPTION
## Summary
- fix tuple parsing loop in console `_parse_args`
- add unit test covering tuple argument parsing

## Testing
- `pytest -k test_console -vv`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hexbytes')*

------
https://chatgpt.com/codex/tasks/task_b_683fc45f09f48327b1605273e524f635